### PR TITLE
fix(coverage): exclude dashboard from coverage measurement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ omit = [
     "*/__init__.py",
     "*/integrations/*",  # Optional integrations require external deps
     "*/cli/*",  # Optional CLI interface
+    "*/dashboard/*",  # Optional Streamlit dashboard requires external deps
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
Like cli/ and integrations/, the dashboard package requires the optional Streamlit dependency and cannot be meaningfully unit-tested. Adding it to coverage omit restores the total coverage above 80%.